### PR TITLE
Release v1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v1.2.0
+- Update docker image to use CommandBox v5.9.0
+- Use full CommandBox in docker instead of minibox
+- Fix prompt check with CommandBox v5.9.0
+- Add support for rendering HTML output
+
 ## v1.1.0
 
 - Add % prefix for magic commands to match the iPython naming scheme i.e. `%install` and `%loadjar`

--- a/build.Dockerfile
+++ b/build.Dockerfile
@@ -15,13 +15,12 @@ RUN apt-get update \
     && apt-get update \
     && apt-get install -y zulu11-jre-headless
 
-# Install CommandBox from minibox to help make the image smaller
-COPY --from=foundeo/minibox:2023.01 /opt/box /home/jovyan/.bin
-COPY --from=foundeo/minibox:2023.01 /root/.CommandBox/ /home/jovyan/.CommandBox/
+# Install CommandBox v5.9.0
+COPY --from=ortussolutions/commandbox@sha256:c1deedac96dd8ef1826ab5f0701c5c3748027acaf2191d11e0c62483963639d5 /usr/local/bin/box /home/jovyan/.bin/box
+COPY --from=ortussolutions/commandbox@sha256:c1deedac96dd8ef1826ab5f0701c5c3748027acaf2191d11e0c62483963639d5 /usr/local/lib/CommandBox/ /home/jovyan/.CommandBox/
 
 RUN chmod a+x /home/jovyan/.bin/box \
     && chown -R $NB_UID /home/jovyan/.bin \
-    && curl https://raw.githubusercontent.com/jsteinshouer/commandbox/4cf42084ebd17b4275a416632b54cc809f8f0f43/src/cfml/system/util/REPLParser.cfc >/home/jovyan/.CommandBox/cfml/system/util/REPLParser.cfc \
     && chown -R $NB_UID /home/jovyan/.CommandBox \
     && echo "commandbox_home=${COMMANDBOX_HOME}" > /home/jovyan/.bin/commandbox.properties
 

--- a/build.Dockerfile
+++ b/build.Dockerfile
@@ -21,6 +21,7 @@ COPY --from=foundeo/minibox:2023.01 /root/.CommandBox/ /home/jovyan/.CommandBox/
 
 RUN chmod a+x /home/jovyan/.bin/box \
     && chown -R $NB_UID /home/jovyan/.bin \
+    && curl https://raw.githubusercontent.com/jsteinshouer/commandbox/4cf42084ebd17b4275a416632b54cc809f8f0f43/src/cfml/system/util/REPLParser.cfc >/home/jovyan/.CommandBox/cfml/system/util/REPLParser.cfc \
     && chown -R $NB_UID /home/jovyan/.CommandBox \
     && echo "commandbox_home=${COMMANDBOX_HOME}" > /home/jovyan/.bin/commandbox.properties
 

--- a/cfml_kernel/box_wrapper.py
+++ b/cfml_kernel/box_wrapper.py
@@ -9,6 +9,8 @@ class CommandBoxWrapper():
         # logging.basicConfig(filename='box_wrapper_debug.log',
         #                     encoding='utf-8', level=LOG_LEVEL)
         self.CF_REPL_TYPE = repl_type
+        # New version of commandbox (5.9.0) uses a prompt with the current working directory in it
+        self.PROMPT_STRINGS.append("CommandBox:" + os.getcwd().split(os.sep)[-1] + ">");
         self.box_shell = self._create_process()
         self._search_for_output()
         self._start_repl()

--- a/cfml_kernel/cfml/kernel.py
+++ b/cfml_kernel/cfml/kernel.py
@@ -21,9 +21,14 @@ class CFMLKernel(Kernel):
                    allow_stdin=False):
         if not silent:
 
-            output = self.box_wrapper.do_execute(code);
-            stream_content = {'name': 'stdout', 'text': output}
-            self.send_response(self.iopub_socket, 'stream', stream_content)
+            responses = self.box_wrapper.do_execute(code)
+
+            for content in responses:
+                if isinstance( content, str ):
+                    stream_content = {'name': 'stdout', 'text': content}
+                    self.send_response(self.iopub_socket, 'stream', stream_content)
+                else:
+                    self.send_response(self.iopub_socket, 'display_data', content)
 
         return {'status': 'ok',
                 # The base class increments the execution count

--- a/cfml_kernel/cfscript/kernel.py
+++ b/cfml_kernel/cfscript/kernel.py
@@ -21,9 +21,14 @@ class CFScriptKernel(Kernel):
                    allow_stdin=False):
         if not silent:
 
-            output = self.box_wrapper.do_execute(code);
-            stream_content = {'name': 'stdout', 'text': output}
-            self.send_response(self.iopub_socket, 'stream', stream_content)
+            responses = self.box_wrapper.do_execute(code)
+
+            for content in responses:
+                if isinstance( content, str ):
+                    stream_content = {'name': 'stdout', 'text': content}
+                    self.send_response(self.iopub_socket, 'stream', stream_content)
+                else:
+                    self.send_response(self.iopub_socket, 'display_data', content)
 
         return {'status': 'ok',
                 # The base class increments the execution count

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
             target: development
         volumes:
             - .:/workspace
-            - ./notebooks:/home/jovyan/cfml_notebooks
+            - ./notebook_examples:/home/jovyan/notebook_examples
         ports:
             - 8888:8888
         environment:


### PR DESCRIPTION
- Update docker image to use CommandBox v5.9.0
- Use full CommandBox in docker instead of minibox
- Fix prompt check with CommandBox v5.9.0
- Add support for rendering HTML output